### PR TITLE
Dispatch to new HuBMAP documentation site

### DIFF
--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        repo: ["sennetconsortium/documentation", "hubmapconsortium/software-docs"]
+        repo: ["sennetconsortium/documentation", "hubmapconsortium/software-docs", "hubmapconsortium/documentation"]
     timeout-minutes: 5
     steps:
       - name: Dispatch to workflows


### PR DESCRIPTION
Dispatch changes in the Data Submission Guide to the new `hubmapconsortium/documentation` repo, which is exposed at https://docs.hubmapconsortium.org 